### PR TITLE
Neovim - Plugin links, GCC

### DIFF
--- a/nvim/lua/acikgozb/plugins/autocomplete.lua
+++ b/nvim/lua/acikgozb/plugins/autocomplete.lua
@@ -5,7 +5,7 @@ return {
 	{
 		"L3MON4D3/LuaSnip",
 		dependencies = {
-			"saadparwaiz/cmp_luasnip",
+			"saadparwaiz1/cmp_luasnip",
 			"rafamadriz/friendly-snippets",
 		},
 	},

--- a/setup/roles/acikgozb.nvim/defaults/main.yml
+++ b/setup/roles/acikgozb.nvim/defaults/main.yml
@@ -4,6 +4,12 @@ neovim:
     url: https://github.com/neovim/neovim/releases/download/nightly/nvim-linux64.tar.gz
   darwin:
     url: https://github.com/neovim/neovim/releases/download/nightly/nvim-macos-arm64.tar.gz
+# GCC package lists
+gcc_packages:
+  Debian:
+    - "build-essential"
+  Fedora:
+    - "@C Development Tools and Libraries"
 # Languages
 # Go
 go_version: 1.22.4

--- a/setup/roles/acikgozb.nvim/tasks/installation/Linux-install.yml
+++ b/setup/roles/acikgozb.nvim/tasks/installation/Linux-install.yml
@@ -1,22 +1,36 @@
-- name: Download Nightly binary.
-  ansible.builtin.get_url:
-    url: "{{ neovim.linux.url }}"
-    dest: "/tmp/nvim-linux"
-    mode: "0644"
-- name: Unarchive the binary from download.
-  ansible.builtin.unarchive:
-    remote_src: true
-    src: "/tmp/nvim-linux"
-    dest: "/tmp"
-- name: Run the binary to install.
-  ansible.builtin.shell: >
-    /tmp/nvim-linux64/bin/nvim
-  register: result
-  changed_when: result.stdin is defined
-- name: Remove the temporary files.
-  ansible.builtin.file:
-    path: "{{ item }}"
-    state: absent
-  with_items:
-    - "/tmp/nvim-linux"
-    - "/tmp/nvim-linux64"
+- name: Download and install Neovim Nightly.
+  become_user: "{{ lookup('env', 'USER') }}"
+  block:
+    - name: Download Nightly binary.
+      ansible.builtin.get_url:
+        url: "{{ neovim.linux.url }}"
+        dest: "/tmp/nvim-linux"
+
+    - name: Ensure that $HOME/lib exists for lib code.
+      ansible.builtin.file:
+        path: ~/lib
+        state: directory
+
+    - name: Unarchive the binary under $HOME/lib.
+      ansible.builtin.unarchive:
+        remote_src: true
+        src: "/tmp/nvim-linux"
+        dest: "~/lib"
+
+    - name: Ensure that a symlink exists for Neovim binary, under $HOME/bin.
+      ansible.builtin.file:
+        src: ~/lib/nvim-linux64/bin/nvim
+        dest: ~/bin/nvim
+        state: link
+
+    - name: Remove the installation file.
+      ansible.builtin.file:
+        path: /tmp/nvim-linux
+        state: absent
+
+- name: "[Distro Specific] Ensure that gcc and helper tools exist on the host."
+  ansible.builtin.package:
+    name: "{{ item }}"
+    state: present
+  with_items: "{{ gcc_packages[ansible_distribution] }}"
+


### PR DESCRIPTION
This PR aims to resolve [installation defects on Fedora](https://github.com/acikgozb/dotfiles/issues/6).

- The repository link for `cmp_luasnip` is updated.
- A new distro specific task is added to ensure that `gcc` and helper tools (e.g `make`) exist on host.
- The Neovim installation is fixed, instead of running the binary, the unarchived files are moved under `$HOME/lib`, with a symlink that exists in `$HOME/bin`.