### PR TITLE
Add basic Terraform support

### DIFF
--- a/nvim/lua/acikgozb/plugins/format.lua
+++ b/nvim/lua/acikgozb/plugins/format.lua
@@ -13,10 +13,11 @@ return {
 				markdown = { { "prettier" } },
 				go = { "gofumpt", "goimports" },
 				csharp = { "csharpier" },
-				sh = { "beautysh" },
+				bash = { "beautysh" },
 				yaml = { "yamlfmt" },
 				["yaml.ansible"] = { "yamlfmt", "ansible-lint" },
 				sql = { "sqlfmt" },
+				tf = { "terraform_fmt" },
 			},
 			format_on_save = {
 				lsp_fallback = true,

--- a/nvim/lua/acikgozb/plugins/lsp.lua
+++ b/nvim/lua/acikgozb/plugins/lsp.lua
@@ -125,6 +125,16 @@ return {
 				on_attach = onAttach,
 			})
 
+			lspconfig.terraformls.setup({
+				capabilities = capabilities,
+				on_attach = onAttach,
+				experimentalFeatures = {
+					validateOnSave = true,
+					prefillRequiredFields = true,
+				},
+				ignoreSingleFileWarning = true,
+			})
+
 			lspconfig.docker_compose_language_service.setup({
 				capabilities = capabilities,
 				on_attach = onAttach,

--- a/nvim/lua/acikgozb/plugins/treesitter.lua
+++ b/nvim/lua/acikgozb/plugins/treesitter.lua
@@ -26,6 +26,7 @@ return {
 				"markdown",
 				"bash",
 				"ruby",
+				"terraform",
 			},
 			sync_install = false,
 			highlight = { enable = true },

--- a/nvim/lua/acikgozb/remap.lua
+++ b/nvim/lua/acikgozb/remap.lua
@@ -50,3 +50,10 @@ vim.opt.swapfile = false
 
 -- sync nvim shell with system shell
 vim.opt.shell = os.getenv("SHELL")
+
+-- override certain filetypes explicitly
+vim.filetype.add({
+	extension = {
+		tf = "terraform",
+	},
+})


### PR DESCRIPTION
Basic Terraform support is added to dotfiles via:

- `terraformls` as the LSP
- `terraform_fmt` as the formatter
- `terraform` Treesitter plugin for syntax highlighting

Also, a simple filetype mapping is added to explicitly assign `.tf` files as Terraform files.