### PR TITLE
Finalize Neovim update

### DIFF
--- a/kitty/kitty.conf
+++ b/kitty/kitty.conf
@@ -1,5 +1,5 @@
 # Fonts
-font_size 15.0
+font_size 16.0
 
 font_family UbuntuMono Nerd Font Mono
 bold_font UbuntuMono Nerd Font Mono Bold

--- a/nvim/lua/acikgozb/plugins/format.lua
+++ b/nvim/lua/acikgozb/plugins/format.lua
@@ -1,14 +1,16 @@
 return {
 	"stevearc/conform.nvim",
 	config = function()
-		require('conform').setup({
+		local conform = require("conform")
+
+		conform.setup({
 			formatters_by_ft = {
 				lua = { "stylua" },
-				javascript = {  "eslint_d" },
-				typescript = {  "eslint_d" },
+				javascript = { "eslint_d" },
+				typescript = { "eslint_d" },
 				json = { "fixjson", "jq" },
-				html = {  "eslint_d" },
-				markdown = {  "prettier"  },
+				html = { "eslint_d" },
+				markdown = { "prettier" },
 				go = { "gofumpt", "goimports" },
 				csharp = { "csharpier" },
 				bash = { "beautysh" },
@@ -20,13 +22,13 @@ return {
 				lsp_format = "fallback",
 				timeout_ms = 500,
 			},
-      -- Set the log level. Use `:ConformInfo` to see the location of the log file.
-      log_level = vim.log.levels.ERROR,
-      -- Conform will notify you when a formatter errors
-      notify_on_error = true,
-      -- Conform will notify you when no formatters are available for the buffer
-      notify_no_formatters = true,
-      -- Custom formatters and overrides for built-in formatters
+			-- Set the log level. Use `:ConformInfo` to see the location of the log file.
+			log_level = vim.log.levels.ERROR,
+			-- Conform will notify you when a formatter errors
+			notify_on_error = true,
+			-- Conform will notify you when no formatters are available for the buffer
+			notify_no_formatters = true,
+			-- Custom formatters and overrides for built-in formatters
 			formatters = {
 				yamlfmt = {
 					prepend_args = { "-conf", os.getenv("XDG_CONFIG_HOME") .. "/yamlfmt/.yamlfmt.yml" },

--- a/nvim/lua/acikgozb/plugins/statusline.lua
+++ b/nvim/lua/acikgozb/plugins/statusline.lua
@@ -4,10 +4,51 @@ return {
 	config = function()
 		local lualine = require("lualine")
 
+		local colors = {
+			blue = "#66b2b2",
+			black = "#1c1c1c",
+			green = "#1bfd9c",
+			gray = "#404040",
+			white = "#d1d1d1",
+		}
+
+		local theme = {
+			normal = {
+				a = { bg = colors.blue, fg = colors.black, gui = "bold" },
+				b = { bg = colors.black, fg = colors.blue },
+				c = { bg = colors.black },
+			},
+			visual = {
+				a = { bg = colors.black, fg = colors.green, gui = "bold" },
+				b = { bg = colors.black, fg = colors.white },
+				c = { bg = colors.black },
+			},
+			insert = {
+				a = { bg = colors.black, fg = colors.green, gui = "bold" },
+				b = { bg = colors.black, fg = colors.white },
+				c = { bg = colors.black },
+			},
+			command = {
+				a = { bg = colors.black, fg = colors.green, gui = "bold" },
+				b = { bg = colors.black, fg = colors.white },
+				c = { bg = colors.black },
+			},
+			inactive = {
+				a = { bg = colors.black, fg = colors.green, gui = "bold" },
+				b = { bg = colors.black, fg = colors.white },
+				c = { bg = colors.black },
+			},
+			replace = {
+				a = { bg = colors.black, fg = colors.green, gui = "bold" },
+				b = { bg = colors.black, fg = colors.white },
+				c = { bg = colors.black },
+			},
+		}
+
 		lualine.setup({
 			options = {
 				icons_enabled = true,
-				theme = "auto",
+				theme = theme,
 				component_separators = { left = "", right = "" },
 				section_separators = { left = "", right = "" },
 			},

--- a/nvim/lua/acikgozb/plugins/theme.lua
+++ b/nvim/lua/acikgozb/plugins/theme.lua
@@ -30,7 +30,7 @@ return {
 					nvim_cmp = true,
 					treesitter = true,
 					telescope = true,
-					lualine = true,
+					lualine = false,
 				},
 
 				-- gitsigns colors

--- a/nvim/lua/acikgozb/plugins/trouble.lua
+++ b/nvim/lua/acikgozb/plugins/trouble.lua
@@ -1,26 +1,37 @@
 return {
 	"folke/trouble.nvim",
-	dependencies = { "nvim-tree/nvim-web-devicons" },
-	config = function()
-		local trouble = require("trouble")
-
-		vim.keymap.set("n", "<leader>xx", function()
-			trouble.toggle()
-		end)
-		vim.keymap.set("n", "<leader>xw", function()
-			trouble.toggle("workspace_diagnostics")
-		end)
-		vim.keymap.set("n", "<leader>xd", function()
-			trouble.toggle("document_diagnostics")
-		end)
-		vim.keymap.set("n", "<leader>xq", function()
-			trouble.toggle("quickfix")
-		end)
-		vim.keymap.set("n", "<leader>xl", function()
-			trouble.toggle("loclist")
-		end)
-		vim.keymap.set("n", "gR", function()
-			trouble.toggle("lsp_references")
-		end)
-	end,
+	opts = {},
+	cmd = "Trouble",
+	keys = {
+		{
+			"<leader>xx",
+			"<cmd>Trouble diagnostics toggle<cr>",
+			desc = "Diagnostics (Trouble)",
+		},
+		{
+			"<leader>xX",
+			"<cmd>Trouble diagnostics toggle filter.buf=0<cr>",
+			desc = "Buffer Diagnostics (Trouble)",
+		},
+		{
+			"<leader>cs",
+			"<cmd>Trouble symbols toggle focus=false<cr>",
+			desc = "Symbols (Trouble)",
+		},
+		{
+			"<leader>cl",
+			"<cmd>Trouble lsp toggle focus=false win.position=right<cr>",
+			desc = "LSP Definitions / references / ... (Trouble)",
+		},
+		{
+			"<leader>xL",
+			"<cmd>Trouble loclist toggle<cr>",
+			desc = "Location List (Trouble)",
+		},
+		{
+			"<leader>xQ",
+			"<cmd>Trouble qflist toggle<cr>",
+			desc = "Quickfix List (Trouble)",
+		},
+	},
 }

--- a/tmux/tmux.conf
+++ b/tmux/tmux.conf
@@ -6,6 +6,7 @@ set -g @plugin 'tmux-plugins/tmux-sensible'
 
 # Theme
 set -g @plugin 'niksingh710/minimal-tmux-status'
+set -g @minimal-tmux-bg "#66b2b2" # The blue used in darkvoid.nvim.
 
 # Remove the delay when pressed the ESC key
 set -sg escape-time 0


### PR DESCRIPTION
- The Neovim update brought in breaking changes in several plugins, `trouble.nvim` being one of them. The configuration is entirely different now, therefore the plugin usage is updated.
- A custom theme is written to disable the ugly gray coloring for section C of `lualine.nvim`.
- Font size is incresed via `kitty.conf`.
- Active `tmux` window background color is changed to be in sync with Neovim theme.