### PR TITLE
Update git config to utilize local Git hooks

### DIFF
--- a/git/config
+++ b/git/config
@@ -5,3 +5,7 @@
     pretty = format:%h %ad %Cgreen%aN %d %s
 [color]
     ui = true
+[core]
+    hooksPath = /Users/acikgozb/.config/git/hooks
+[init]
+    defaultBranch = main

--- a/git/hooks/prepare-commit-msg
+++ b/git/hooks/prepare-commit-msg
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+
+set -e 
+
+COMMIT_MSG_FILE=$1
+
+IFS="/" read -r -a GIT_BRANCH < <(git rev-parse --abbrev-ref HEAD)
+
+# ${GIT_BRANCH[-1]} for bash 4.0+.
+COMMIT_TITLE=${GIT_BRANCH[${#GIT_BRANCH[@]} - 1]}
+
+sed -i '' -e "1 s/^.*$/\[$COMMIT_TITLE\]/" "$COMMIT_MSG_FILE"
+
+
+
+
+

--- a/nvim/lua/acikgozb/plugins/git.lua
+++ b/nvim/lua/acikgozb/plugins/git.lua
@@ -42,10 +42,6 @@ local GitStatus = function()
 	})
 end
 
-local GitBlame = function()
-	vim.cmd(":Git blame")
-end
-
 local GitMergetool = function()
 	DirectedPane({
 		command = ":Git mergetool",
@@ -59,6 +55,14 @@ local GitDiffBuffer = function()
 	})
 end
 
+local GitBlame = function()
+	vim.cmd(":Git blame")
+end
+
+local GitResolveConflict = function()
+	vim.cmd(":Gvdiffsplit!")
+end
+
 return {
 	{
 		"tpope/vim-fugitive",
@@ -69,6 +73,7 @@ return {
 			vim.keymap.set("n", "<leader>gb", GitBlame, { noremap = true })
 			vim.keymap.set("n", "<leader>gs", GitStatus, { noremap = true })
 			vim.keymap.set("n", "<leader>gmc", GitMergetool, { noremap = true })
+			vim.keymap.set("n", "<leader>grc", GitResolveConflict, { noremap = true })
 			vim.keymap.set("n", "<leader>gdb", GitDiffBuffer, { noremap = true })
 		end,
 	},


### PR DESCRIPTION
- More `vim-fugitive` mappings are added for conflict resolution.
- `core.hooksPath` is added to have a central place for custom local Git hooks.
- `init.defaultBranch` is added to sync the default branch naming with Git providers (e.g GitHub).

Also, custom `prepare-commit-msg` Git hook is implemented to add branch names to commit titles.

I've come to get used to this naming convention over time. This is a personal choice which works upon a strict format `<author/branch-name>`.