### PR TITLE
Configure VRC to show the executed curl command

### DIFF
--- a/nvim/lua/acikgozb/plugins/rest.lua
+++ b/nvim/lua/acikgozb/plugins/rest.lua
@@ -3,16 +3,22 @@ return {
 	config = function()
 		-- Set the default response content type to JSON
 		vim.g.vrc_response_default_content_type = "application/json"
+
 		-- Use jq to format the response
 		vim.g.vrc_auto_format_response_patterns = {
 			json = "jq",
 		}
+
 		-- Turn off the default key binding
 		vim.g.vrc_set_default_mapping = 0
+
 		-- Set the output buffer name
-		vim.g.vrc_output_buffer_name = "_OUTPUT.json"
+		vim.g.vrc_output_buffer_name = "vrc.buffer.json"
+
+		-- Show the constructed curl command by VRC - used to share output with other people.
+		vim.g.vrc_show_command = 1
 
 		-- Custom keymap to run REST query under the cursor
-		vim.keymap.set("n", "<leader>xr", ":call VrcQuery()<CR>")
+		vim.keymap.set("n", "<leader>vq", ":call VrcQuery()<CR>")
 	end,
 }


### PR DESCRIPTION
Even though we can skip using curl with VRC, it is sometimes needed to remove the abstraction and use the underlying curl command.

Therefore, a flag is used to output curl command on every VRC invocation.