### PR TITLE
Add a special workspace

### DIFF
--- a/.config/hypr/hyprland.conf
+++ b/.config/hypr/hyprland.conf
@@ -113,7 +113,7 @@ decoration {
           size              = 2
           passes            = 3
           new_optimizations = true
-          xray              = true
+          xray              = false
           ignore_opacity    = true
     }
 }
@@ -122,7 +122,6 @@ layerrule = blur, rofi
 
 animations {
     enabled = false
-    first_launch_animation = true
 }
 
 # See https://wiki.hyprland.org/Configuring/Master-Layout/ for more
@@ -220,9 +219,9 @@ bind = $mainMod SHIFT, 8, movetoworkspace, 8
 bind = $mainMod SHIFT, 9, movetoworkspace, 9
 bind = $mainMod SHIFT, 0, movetoworkspace, 10
 
-# Example special workspace (scratchpad)
-bind = $mainMod, S, togglespecialworkspace, magic
-bind = $mainMod SHIFT, S, movetoworkspace, special:magic
+# Special workspace.
+workspace = special:terminal, on-created-empty:[tile] $terminal, persistent:false
+bind = $mainMod, S, togglespecialworkspace, terminal
 
 # Scroll through existing workspaces with mainMod + scroll
 bind = $mainMod, mouse_down, workspace, e+1

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ nvim/lua/acikgozb/secrets.lua
 tmux/plugins
 installation/vars/user_vars.yml
 .ansible
+**/files

--- a/README.md
+++ b/README.md
@@ -82,9 +82,9 @@ Here is how an empty workspace looks like:
     <image src="https://github.com/user-attachments/assets/665404b6-ffed-49ac-82b5-742353d76527"></image>
 </details>
 
-**Special Workspaces**
+**Special Workspaces aka scratchpads**
 
-Currently, there are no special workspaces configured for `hyprland`.
+There is one non-persistent special workspace called `terminal` which triggers `alacritty` on a floating (tiled) window to execute less frequent commands.
 
 ### <a id='terminal'></a> Terminal
 

--- a/installation/roles/acikgozb.system/templates/hyprland.conf.j2
+++ b/installation/roles/acikgozb.system/templates/hyprland.conf.j2
@@ -220,9 +220,9 @@ bind = $mainMod SHIFT, 8, movetoworkspace, 8
 bind = $mainMod SHIFT, 9, movetoworkspace, 9
 bind = $mainMod SHIFT, 0, movetoworkspace, 10
 
-# Example special workspace (scratchpad)
-bind = $mainMod, S, togglespecialworkspace, magic
-bind = $mainMod SHIFT, S, movetoworkspace, special:magic
+# Special workspace.
+workspace = special:terminal, on-created-empty:[tile] $terminal, persistent:false
+bind = $mainMod, S, togglespecialworkspace, terminal
 
 # Scroll through existing workspaces with mainMod + scroll
 bind = $mainMod, mouse_down, workspace, e+1


### PR DESCRIPTION
A special workspace (scratchpad) is defined for Hyprland that executes `$terminal` when it is created.

`$mainMod + S` is added as a new binding to toggle the special workspace.

Other changes:

- `xray` field is disabled for blur.
- `first_launch_animation` is removed completely.
- Processed templates files are added to `.gitignore`.