### PR TITLE
Install `hugo` for static site development

### DIFF
--- a/installation/roles/acikgozb.editor/defaults/main.yml
+++ b/installation/roles/acikgozb.editor/defaults/main.yml
@@ -39,28 +39,39 @@ programs:
       url:
         amd64: 'https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-amd64'
       extract: "false"
+
     - name: shellcheck
       url:
         amd64: 'https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.x86_64.tar.xz'
       extract: "true"
       strip: "true"
+
     - name: golangci-lint
       url:
         amd64: 'https://github.com/golangci/golangci-lint/releases/download/v1.59.1/golangci-lint-1.59.1-linux-amd64.tar.gz'
       extract: "true"
       strip: "true"
+
     - name: fzf
       url:
         amd64: 'https://github.com/junegunn/fzf/releases/download/v0.60.2/fzf-0.60.2-linux_amd64.tar.gz'
       extract: "true"
       strip: "false"
+
     - name: rg
       url:
         amd64: 'https://github.com/BurntSushi/ripgrep/releases/download/14.1.1/ripgrep-14.1.1-x86_64-unknown-linux-musl.tar.gz'
       extract: "true"
       strip: "true"
+
     - name: fd
       url:
         amd64: 'https://github.com/sharkdp/fd/releases/download/v10.2.0/fd-v10.2.0-x86_64-unknown-linux-gnu.tar.gz'
       extract: "true"
       strip: "true"
+
+    - name: hugo
+      url:
+        amd64: 'https://github.com/gohugoio/hugo/releases/download/v0.145.0/hugo_0.145.0_linux-amd64.tar.gz'
+      extract: "true"
+      strip: "false"


### PR DESCRIPTION
[Hugo](https://gohugo.io/) is installed by adding its prebuilt binary to `acikgozb.editor`.