### PR TITLE
Add Hyprland binds to move windows in workspaces

### DIFF
--- a/.config/hypr/hyprland.conf
+++ b/.config/hypr/hyprland.conf
@@ -189,11 +189,17 @@ bind = SHIFT, PRINT, exec, hyprshot -m region
 bind = ,F11, exec, brightnessctl -d tpacpi::kbd_backlight set 0
 bind = ,F12, exec, brightnessctl -d tpacpi::kbd_backlight set 1
 
-# Move focus with mainMod + vim directional keys.
-bind = $mainMod, H, movefocus, l
-bind = $mainMod, L, movefocus, r
-bind = $mainMod, J, movefocus, d
-bind = $mainMod, K, movefocus, u
+# Move window focus.
+bind = $mainMod_SHIFT, H, movefocus, l
+bind = $mainMod_SHIFT, L, movefocus, r
+bind = $mainMod_SHIFT, J, movefocus, d
+bind = $mainMod_SHIFT, K, movefocus, u
+
+# Change windows' positions.
+bind = $mainMod, H, movewindow, l
+bind = $mainMod, L, movewindow, r
+bind = $mainMod, J, movewindow, d
+bind = $mainMod, K, movewindow, u
 
 # Switch workspaces.
 bind = $mainMod, 1, workspace, 1


### PR DESCRIPTION
The Hyprland bindings related with windows are changed:

Super + Shift + [h,j,k,l] -> Moves current focus to the window in the given direction.

Super + [h,j,k,l] -> Moves the active window to the given direction.

Vim directional keys are used for directions.