### PR TITLE
Add Helix installation to dotfiles

### DIFF
--- a/.config/bash/.bashrc
+++ b/.config/bash/.bashrc
@@ -46,7 +46,7 @@ export ANSIBLE_HOME="${XDG_CONFIG_HOME}/ansible"
 export ANSIBLE_CONFIG="${XDG_CONFIG_HOME}/ansible/ansible.cfg"
 export ANSIBLE_GALAXY_CACHE_DIR="${XDG_CACHE_HOME}/ansible/galaxy_cache"
 
-export EDITOR="nvim"
+export EDITOR="helix"
 
 # Starship.
 eval "$(starship init bash)"
@@ -72,3 +72,4 @@ alias clip='wl-copy'
 alias src='. $XDG_CONFIG_HOME/bash/.bashrc'
 alias ftsys='fastfetch'
 alias tee='gtee'
+alias hx='helix'

--- a/.config/helix/config.toml
+++ b/.config/helix/config.toml
@@ -1,0 +1,47 @@
+theme = "rose_pine"
+
+[editor]
+line-number = "relative"
+mouse = false
+shell = ["/usr/bin/bash", "-c"]
+continue-comments = true
+true-color = true
+color-modes = true
+popup-border = "all"
+clipboard-provider = "wayland"
+auto-pairs = false
+jump-label-alphabet = "jfkdls;aurieowpqnvmcxz"
+completion-timeout = 5
+
+[editor.cursor-shape]
+insert = "bar"
+normal = "block"
+
+[editor.file-picker]
+hidden = false
+follow-symlinks = true
+
+[editor.statusline]
+mode.normal = "NORMAL"
+mode.insert = "INSERT"
+mode.select = "SELECT"
+right = ["version-control", "diagnostics", "file-type"]
+
+[editor.soft-wrap]
+enable = true
+wrap-at-text-width = true
+
+[editor.inline-diagnostics]
+cursor-line = "disable"
+
+# Keymaps.
+[keys.normal]
+a = ["append_mode", "collapse_selection"]
+i = ["insert_mode", "collapse_selection"]
+ret = "goto_word"
+
+# NOTE: Experimental, I might stop using jumplist later on.
+C-h = "jump_backward"
+C-l = "jump_forward"
+[keys.normal.space]
+a = "save_selection"

--- a/.config/helix/language.toml
+++ b/.config/helix/language.toml
@@ -1,0 +1,82 @@
+# YAML.
+[[language-server.yaml-language-server.config.yaml]]
+completion = true
+validate = true
+hover = true
+format = { enable = true, bracketSpacing = true }
+
+[[language-server.yaml-language-server.config.yaml.schemaStore]]
+enable = true
+url = "https://www.schemastore.org/api/json/catalog.json"
+
+# Ansible.
+[[language-server.ansible-language-server.config.ansible]]
+python = { interpreterPath = "python" }
+executionEnvironment = {enabled = false}
+ansible = { useFullyQualifiedCollectionNames = true }
+
+[[language-server.ansible-language-server.config.ansible.validation]]
+enabled = true
+lint = { enabled = true, path = "ansible-lint" }
+
+# Bash.
+[[language-server.bash-language-server.config.bashIde]]
+globPattern = "*@(.sh|.inc|.bash|.command)"
+
+# Lua.
+[[language-server.lua-language-server.config.Lua]]
+version = "LuaJIT"
+
+[[language-server.lua-language-server.config.signatureHelp]]
+enabled = true
+
+# Go.
+[[language-server.gopls.config.gopls]]
+completeUnimported = true
+usePlaceholders = true
+staticcheck = true
+analyses = { unusedparams = true }
+
+# JavaScript (TypeScript)
+[[language-server.typescript-language-server.config.typescript.format]]
+enable = true
+insertSpaceAfterConstructor = true
+semicolons = true
+
+[[language-server.typescript-language-server.config.typescript.inlayHints]]
+enumMemberValues = true
+functionLikeReturnTypes = true
+parameterNames = { enabled = "all", suppressWhenArgumentMatchesName = false }
+parameterTypes = { enabled = true }
+
+[[language-server.typescript-language-server.config.typescript.suggest]]
+completeFunctionCalls = true
+
+[[language-server.typescript-language-server.config.javascript.format]]
+enable = true
+insertSpaceAfterConstructor = true
+semicolons = true
+
+[[language-server.typescript-language-server.config.javascript.inlayHints]]
+enumMemberValues = true
+functionLikeReturnTypes = true
+parameterNames = { enabled = "all", suppressWhenArgumentMatchesName = false }
+parameterTypes = { enabled = true }
+
+[[language-server.typescript-language-server.config.javascript.suggest]]
+completeFunctionCalls = true
+
+# Terraform (manual configuration is needed.)
+[[language]]
+name = "hcl"
+language-servers = [ "terraform-ls" ]
+language-id = "terraform"
+
+[[language]]
+name = "tfvars"
+language-servers = [ "terraform-ls" ]
+language-id = "terraform-vars"
+
+[language-server.terraform-ls]
+command = "terraform-ls"
+args = ["serve"]

--- a/.config/helix/themes/rose_pine.toml
+++ b/.config/helix/themes/rose_pine.toml
@@ -1,0 +1,199 @@
+# Author: Rosé Pine <hi@rosepinetheme.com>
+# Upstream: https://github.com/rose-pine/helix
+# Contributing:
+#   Please submit changes to https://github.com/rose-pine/helix.
+#   The Rosé Pine team will update Helix, including you as a co-author.
+
+"ui.background" = { fg = "rose" }
+"ui.background.separator" = { bg = "base" }
+
+"ui.cursor" = { fg = "rose", bg = "rose" }
+"ui.cursor.normal" = { fg = "rose", bg = "rose" }
+"ui.cursor.insert" = { fg = "rose", bg = "rose" }
+# "ui.cursor.select" = {}
+"ui.cursor.match" = { fg = "rose", bg = "highlight_med" }
+"ui.cursor.primary" = { fg = "muted", bg = "rose" }
+
+# "ui.gutter" = {}
+# "ui.gutter.selected" = {}
+
+"ui.linenr" = { fg = "muted" }
+"ui.linenr.selected" = { fg = "text" }
+
+"ui.bufferline" = { fg = "muted", bg = "base" }
+"ui.bufferline.active" = { fg = "text", bg = "overlay" }
+"ui.statusline" = { fg = "subtle" }
+"ui.statusline.inactive" = { fg = "muted" }
+"ui.statusline.normal" = { fg = "rose" }
+"ui.statusline.insert" = { fg = "foam" }
+"ui.statusline.select" = { fg = "iris" }
+# "ui.statusline.separator" = {}
+
+"ui.popup" = { fg = "rose" }
+"ui.popup.info" = { fg = "rose" }
+
+"ui.picker.header" = { fg = "iris", modifiers = ["bold"] }
+
+"ui.window" = { fg = "overlay", bg = "base" }
+"ui.help" = { fg = "subtle", bg = "overlay" }
+
+"ui.menu" = { fg = "rose" }
+"ui.menu.selected" = { fg = "text" }
+"ui.menu.scroll" = { fg = "muted" }
+
+"ui.text" = { fg = "text" }
+"ui.text.focus" = { bg = "overlay" }
+"ui.text.info" = { fg = "subtle" }
+
+"ui.virtual.jump-label" = { fg = "love", modifiers = ["bold"] }
+"ui.virtual.ruler" = { bg = "overlay" }
+"ui.virtual.whitespace" = { fg = "highlight_high" }
+"ui.virtual.indent-guide" = { fg = "muted" }
+"ui.virtual.inlay-hint" = { fg = "subtle" }
+
+
+
+"ui.selection" = { bg = "overlay" }
+"ui.selection.primary" = { bg = "highlight_med" }
+
+"ui.cursorline.primary" = { bg = "highlight_low" }
+"ui.cursorline.secondary" = { bg = "surface" }
+
+"warning" = "gold"
+"error" = "love"
+"info" = "foam"
+"hint" = "iris"
+"debug" = "rose"
+
+"diagnostic" = { underline = { color = "subtle", style = "curl" } }
+"diagnostic.hint" = { underline = { color = "iris", style = "curl" } }
+"diagnostic.info" = { underline = { color = "foam", style = "curl" } }
+"diagnostic.warning" = { underline = { color = "gold", style = "curl" } }
+"diagnostic.error" = { underline = { color = "love", style = "curl" } }
+"special" = "rose"
+
+"attribute" = "iris"
+
+"type" = "foam"
+# "type.builtin" = ""
+
+"constructor" = "foam"
+
+"constant" = "foam"
+"constant.builtin" = "love"
+"constant.builtin.boolean" = "rose"
+"constant.character" = "gold"
+"constant.character.escape" = "pine"
+"constant.numeric" = "gold"
+# "constant.numeric.integer" = ""
+# "constant.numeric.float" = ""
+
+"string" = "gold"
+# "string.regexp" = ""
+# "string.special" = ""
+# "string.special.path" = ""
+# "string.special.url" = ""
+"string.special.symbol" = "iris"
+
+"comment" = { fg = "muted", modifiers = ["italic"] }
+# "comment.line" = ""
+# "comment.block" = ""
+# "comment.block.documentation" = ""
+
+"variable" = "text"
+"variable.builtin" = "love"
+"variable.parameter" = "iris"
+# "variable.other" = ""
+"variable.other.member" = "foam"
+
+"label" = "foam"
+
+"punctuation" = "subtle"
+# "punctuation.delimiter" = ""
+# "punctuation.bracket" = ""
+# "punctuation.special" = ""
+
+"keyword" = "pine"
+# "keyword.control" = ""
+# "keyword.control.conditional" = ""
+# "keyword.control.repeat" = ""
+# "keyword.control.import" = ""
+# "keyword.control.return" = ""
+# "keyword.control.exception" = ""
+"keyword.operator" = "subtle"
+# "keyword.directive" = ""
+# "keyword.function" = ""
+# "keyword.storage" = ""
+# "keyword.storage.type" = ""
+# "keyword.storage.modifier" = ""
+
+"operator" = "subtle"
+
+"function" = "rose"         # maybe pine
+"function.builtin" = "love"
+# "function.method" = ""
+# "function.macro" = ""
+# "function.special" = ""
+
+"tag" = "foam"
+
+"namespace" = "text"
+
+"markup.heading.marker" = "muted"
+"markup.heading" = { fg = "iris", modifiers = ["bold"] }
+"markup.heading.1" = { fg = "iris", modifiers = ["bold"] }
+"markup.heading.2" = { fg = "foam", modifiers = ["bold"] }
+"markup.heading.3" = { fg = "rose", modifiers = ["bold"] }
+"markup.heading.4" = { fg = "gold", modifiers = ["bold"] }
+"markup.heading.5" = { fg = "pine", modifiers = ["bold"] }
+"markup.heading.6" = { fg = "foam", modifiers = ["bold"] }
+# "markup.heading.completion" = ""
+# "markup.heading.hover" = ""
+"markup.list" = "muted"
+# "markup.list.unnumbered" = ""
+# "markup.list.numbered" = ""
+"markup.bold" = { modifiers = ["bold"] }
+"markup.italic" = { modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
+"markup.link" = "iris"
+"markup.link.url" = { fg = "iris", underline = { color = "iris", style = "line" } }
+"markup.link.label" = "subtle"
+"markup.link.text" = "foam"
+"markup.quote" = "subtle"
+"markup.raw" = "subtle"
+"markup.raw.inline" = "gold"
+# "markup.raw.inline.completion" = {}
+# "markup.raw.inline.hover" = {}
+"markup.raw.block" = "gold"
+# "markup.normal" = ""
+# "markup.normal.completion" = ""
+# "markup.normal.hover" = ""
+
+"diff" = "overlay"
+"diff.plus" = "foam"
+"diff.minus" = "love"
+"diff.delta" = "highlight_high"
+# "diff.delta.moved" = ""
+
+[palette]
+base = "#191724"
+surface = "#1f1d2e"
+overlay = "#26233a"
+muted = "#6e6a86"
+subtle = "#908caa"
+text = "#e0def4"
+love = "#eb6f92"
+love_10 = "#311f30"
+gold = "#f6c177"
+gold_10 = "#30282c"
+rose = "#ebbcba"
+rose_10 = "#2f2834"
+pine = "#31748f"
+pine_10 = "#1a2030"
+foam = "#9ccfd8"
+foam_10 = "#252937"
+iris = "#c4a7e7"
+iris_10 = "#2b2539"
+highlight_low = "#21202e"
+highlight_med = "#403d52"
+highlight_high = "#524f67"

--- a/installation/roles/acikgozb.editor/defaults/main.yml
+++ b/installation/roles/acikgozb.editor/defaults/main.yml
@@ -31,9 +31,29 @@ programs:
   go_install:
     - "github.com/google/yamlfmt/cmd/yamlfmt@latest"
     - "github.com/go-delve/delve/cmd/dlv@latest"
+    - "golang.org/x/tools/gopls@v0.18.1"
   npm_install:
     - name: eslint_d
+
     - name: typescript
+
+    - name: typescript-language-server
+      path: "lib/cli.mjs"
+
+    - name: vscode-langservers-extracted
+
+    - name: yaml-language-server
+      version: next
+      path: "bin/yaml-language-server"
+
+    - name: bash-language-server
+      path: "out/cli.js"
+
+    - name: "@ansible/ansible-language-server"
+
+    - name: "dockerfile-language-server-nodejs"
+
+    - name: "@microsoft/compose-language-service"
   prebuilt:
     - name: jq
       url:
@@ -73,5 +93,22 @@ programs:
     - name: hugo
       url:
         amd64: 'https://github.com/gohugoio/hugo/releases/download/v0.145.0/hugo_0.145.0_linux-amd64.tar.gz'
+      extract: "true"
+      strip: "false"
+
+    - name: marksman
+      url:
+        amd64: 'https://github.com/artempyanykh/marksman/releases/download/2024-12-18/marksman-linux-x64'
+      extract: "false"
+
+    - name: lua-language-server
+      url:
+        amd64: 'https://github.com/LuaLS/lua-language-server/releases/download/3.13.9/lua-language-server-3.13.9-linux-x64.tar.gz'
+      extract: "true"
+      strip: "true"
+
+    - name: terraform-ls
+      url:
+        amd64: 'https://releases.hashicorp.com/terraform-ls/0.36.4/terraform-ls_0.36.4_linux_amd64.zip'
       extract: "true"
       strip: "false"

--- a/installation/roles/acikgozb.editor/tasks/helix/setup-Archlinux.yml
+++ b/installation/roles/acikgozb.editor/tasks/helix/setup-Archlinux.yml
@@ -1,0 +1,54 @@
+- name: "Install and configure Helix."
+  block:
+    - name: "Install Helix via Pacman."
+      community.general.pacman:
+        name: "helix"
+        state: present
+
+    - name: "[Template] Ensure that the Helix configuration file is created."
+      ansible.builtin.template:
+        src: "{{ item }}.j2"
+        dest: "{{ role_path }}/files/{{ item }}"
+        owner: "{{ dotfiles_user }}"
+        group: "{{ dotfiles_user_group }}"
+        mode: "0644"
+      with_items:
+        - helix.config.toml
+        - helix.language.toml
+        - helix.rose_pine.toml
+
+    - name: "Ensure that `dotfiles/.config/helix` exists on the host."
+      ansible.builtin.file:
+        path: "{{ dotfiles_repo_path }}/.config/{{ item }}"
+        state: directory
+        owner: "{{ dotfiles_user }}"
+        group: "{{ dotfiles_user_group }}"
+      with_items:
+        - helix
+        - helix/themes
+
+    - name: "Ensure that the Helix configuration files are copied under `dotfiles/.config/helix`."
+      ansible.builtin.copy:
+        src: "{{ role_path }}/files/{{ item.src }}"
+        dest: "{{ dotfiles_repo_path }}/.config/helix/{{ item.dest }}"
+        owner: "{{ dotfiles_user }}"
+        group: "{{ dotfiles_user_group }}"
+        mode: "0644"
+      with_items:
+        - { src: "helix.config.toml", dest: "config.toml" }
+        - { src: "helix.language.toml", dest: "language.toml" }
+        - { src: "helix.rose_pine.toml", dest: "themes/rose_pine.toml" }
+
+    - name: "Ensure that $XDG_CONFIG_HOME is symlinked with `dotfiles/.config/helix`."
+      ansible.builtin.file:
+        src: "{{ dotfiles_repo_path }}/.config/helix"
+        dest: "{{ xdg_config_home }}/helix"
+        state: link
+        owner: "{{ dotfiles_user }}"
+        group: "{{ dotfiles_user_group }}"
+        force: true
+        follow: false
+        
+
+      
+    

--- a/installation/roles/acikgozb.editor/tasks/languages/rust/setup-Archlinux.yml
+++ b/installation/roles/acikgozb.editor/tasks/languages/rust/setup-Archlinux.yml
@@ -1,7 +1,16 @@
 - name: "Install Rust."
-  become_user: "{{ dotfiles_user }}"
+  become: true
   block:
     - name: "Download and run Rustup."
+      become_user: "{{ dotfiles_user }}"
       ansible.builtin.shell:
         cmd: source {{ xdg_config_home }}/{{ dotfiles_shell }}/.{{ dotfiles_shell }}rc && curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
         executable: "{{ dotfiles_shell_executable_path }}"
+
+    - name: "Ensure that Cargo permissions are set correctly."
+      ansible.builtin.file:
+        path: "{{ xdg_bin_home }}/cargo"
+        state: directory
+        recurse: true
+        owner: "{{ dotfiles_user }}"
+        group: "{{ dotfiles_user_group }}"

--- a/installation/roles/acikgozb.editor/tasks/main.yml
+++ b/installation/roles/acikgozb.editor/tasks/main.yml
@@ -1,5 +1,10 @@
 - name: "[OS Specific] Install and configure Neovim."
   ansible.builtin.include_tasks: ./nvim/setup-{{ ansible_os_family }}.yml
+  when: "editor == 'nvim'"
+
+- name: "[OS Specific] Install and configure Helix."
+  ansible.builtin.include_tasks: ./helix/setup-{{ ansible_os_family }}.yml
+  when: "editor == 'helix'"
 
 - name: "[OS Specific] Install the programming languages."
   ansible.builtin.include_tasks: ./languages/main.yml

--- a/installation/roles/acikgozb.editor/tasks/programs/npm/main.yml
+++ b/installation/roles/acikgozb.editor/tasks/programs/npm/main.yml
@@ -18,6 +18,7 @@
     - name: "Install packages via 'npm install'."
       community.general.npm:
         name: "{{ item.name }}"
+        version: "{{ (item.version is defined) | ternary(item.version, '') }}"
         state: present
         executable: "{{ js_lang_path }}/versions/node/{{ node_version_out.stdout }}/bin/npm"
         path: "{{ npm_pkg_path }}"
@@ -48,6 +49,19 @@
         force: true
         follow: false
       with_items: "{{ find_out.results | map(attribute='files') | flatten }}"
+
+    - name: "Ensure that the tools with custom paths have symlinks under npm_pkg_path."
+      ansible.builtin.file:
+        src: "{{ npm_pkg_path }}/node_modules/{{ item.name }}/{{ item.path }}"
+        dest: "{{ npm_pkg_path }}/{{ item.name }}"
+        state: link
+        owner: "{{ dotfiles_user }}"
+        group: "{{ dotfiles_user_group }}"
+        force: true
+        follow: false
+      with_items: "{{ programs.npm_install }}"
+      when: "item.path is defined"
+               
 
 - name: "Remove Node symlink after installation."
   ansible.builtin.file:

--- a/installation/roles/acikgozb.editor/tasks/programs/prebuilt/main.yml
+++ b/installation/roles/acikgozb.editor/tasks/programs/prebuilt/main.yml
@@ -24,12 +24,12 @@
       with_items: "{{ programs.prebuilt }}"
       when: item.extract == "true"
 
-    - name: "Unarchive the downloads if needed."
+    - name: "Ensure that downloads are unarchived and stripped."
       ansible.builtin.unarchive:
         remote_src: true
         src: /tmp/{{ item.name }}-archive
         dest: /tmp/{{ item.name }}
-        extra_opts: "{{ (item.strip == 'true') | ternary('--strip-components=1', '') }}"
+        extra_opts: "{{ (item.strip == 'true') | ternary('--strip-components=1', []) }}"
       with_items: "{{ programs.prebuilt }}"
       when: item.extract == "true"
 

--- a/installation/roles/acikgozb.editor/templates/helix.config.toml.j2
+++ b/installation/roles/acikgozb.editor/templates/helix.config.toml.j2
@@ -1,0 +1,47 @@
+theme = "rose_pine"
+
+[editor]
+line-number = "relative"
+mouse = false
+shell = ["{{ dotfiles_shell_executable_path }}", "-c"]
+continue-comments = true
+true-color = true
+color-modes = true
+popup-border = "all"
+clipboard-provider = "wayland"
+auto-pairs = false
+jump-label-alphabet = "jfkdls;aurieowpqnvmcxz"
+completion-timeout = 5
+
+[editor.cursor-shape]
+insert = "bar"
+normal = "block"
+
+[editor.file-picker]
+hidden = false
+follow-symlinks = true
+
+[editor.statusline]
+mode.normal = "NORMAL"
+mode.insert = "INSERT"
+mode.select = "SELECT"
+right = ["version-control", "diagnostics", "file-type"]
+
+[editor.soft-wrap]
+enable = true
+wrap-at-text-width = true
+
+[editor.inline-diagnostics]
+cursor-line = "disable"
+
+# Keymaps.
+[keys.normal]
+a = ["append_mode", "collapse_selection"]
+i = ["insert_mode", "collapse_selection"]
+ret = "goto_word"
+
+# NOTE: Experimental, I might stop using jumplist later on.
+C-h = "jump_backward"
+C-l = "jump_forward"
+[keys.normal.space]
+a = "save_selection"

--- a/installation/roles/acikgozb.editor/templates/helix.language.toml.j2
+++ b/installation/roles/acikgozb.editor/templates/helix.language.toml.j2
@@ -1,0 +1,82 @@
+# YAML.
+[[language-server.yaml-language-server.config.yaml]]
+completion = true
+validate = true
+hover = true
+format = { enable = true, bracketSpacing = true }
+
+[[language-server.yaml-language-server.config.yaml.schemaStore]]
+enable = true
+url = "https://www.schemastore.org/api/json/catalog.json"
+
+# Ansible.
+[[language-server.ansible-language-server.config.ansible]]
+python = { interpreterPath = "python" }
+executionEnvironment = {enabled = false}
+ansible = { useFullyQualifiedCollectionNames = true }
+
+[[language-server.ansible-language-server.config.ansible.validation]]
+enabled = true
+lint = { enabled = true, path = "ansible-lint" }
+
+# Bash.
+[[language-server.bash-language-server.config.bashIde]]
+globPattern = "*@(.sh|.inc|.bash|.command)"
+
+# Lua.
+[[language-server.lua-language-server.config.Lua]]
+version = "LuaJIT"
+
+[[language-server.lua-language-server.config.signatureHelp]]
+enabled = true
+
+# Go.
+[[language-server.gopls.config.gopls]]
+completeUnimported = true
+usePlaceholders = true
+staticcheck = true
+analyses = { unusedparams = true }
+
+# JavaScript (TypeScript)
+[[language-server.typescript-language-server.config.typescript.format]]
+enable = true
+insertSpaceAfterConstructor = true
+semicolons = true
+
+[[language-server.typescript-language-server.config.typescript.inlayHints]]
+enumMemberValues = true
+functionLikeReturnTypes = true
+parameterNames = { enabled = "all", suppressWhenArgumentMatchesName = false }
+parameterTypes = { enabled = true }
+
+[[language-server.typescript-language-server.config.typescript.suggest]]
+completeFunctionCalls = true
+
+[[language-server.typescript-language-server.config.javascript.format]]
+enable = true
+insertSpaceAfterConstructor = true
+semicolons = true
+
+[[language-server.typescript-language-server.config.javascript.inlayHints]]
+enumMemberValues = true
+functionLikeReturnTypes = true
+parameterNames = { enabled = "all", suppressWhenArgumentMatchesName = false }
+parameterTypes = { enabled = true }
+
+[[language-server.typescript-language-server.config.javascript.suggest]]
+completeFunctionCalls = true
+
+# Terraform (manual configuration is needed.)
+[[language]]
+name = "hcl"
+language-servers = [ "terraform-ls" ]
+language-id = "terraform"
+
+[[language]]
+name = "tfvars"
+language-servers = [ "terraform-ls" ]
+language-id = "terraform-vars"
+
+[language-server.terraform-ls]
+command = "terraform-ls"
+args = ["serve"]

--- a/installation/roles/acikgozb.editor/templates/helix.rose_pine.toml.j2
+++ b/installation/roles/acikgozb.editor/templates/helix.rose_pine.toml.j2
@@ -1,0 +1,199 @@
+# Author: Rosé Pine <hi@rosepinetheme.com>
+# Upstream: https://github.com/rose-pine/helix
+# Contributing:
+#   Please submit changes to https://github.com/rose-pine/helix.
+#   The Rosé Pine team will update Helix, including you as a co-author.
+
+"ui.background" = { fg = "rose" }
+"ui.background.separator" = { bg = "base" }
+
+"ui.cursor" = { fg = "rose", bg = "rose" }
+"ui.cursor.normal" = { fg = "rose", bg = "rose" }
+"ui.cursor.insert" = { fg = "rose", bg = "rose" }
+# "ui.cursor.select" = {}
+"ui.cursor.match" = { fg = "rose", bg = "highlight_med" }
+"ui.cursor.primary" = { fg = "muted", bg = "rose" }
+
+# "ui.gutter" = {}
+# "ui.gutter.selected" = {}
+
+"ui.linenr" = { fg = "muted" }
+"ui.linenr.selected" = { fg = "text" }
+
+"ui.bufferline" = { fg = "muted", bg = "base" }
+"ui.bufferline.active" = { fg = "text", bg = "overlay" }
+"ui.statusline" = { fg = "subtle" }
+"ui.statusline.inactive" = { fg = "muted" }
+"ui.statusline.normal" = { fg = "rose" }
+"ui.statusline.insert" = { fg = "foam" }
+"ui.statusline.select" = { fg = "iris" }
+# "ui.statusline.separator" = {}
+
+"ui.popup" = { fg = "rose" }
+"ui.popup.info" = { fg = "rose" }
+
+"ui.picker.header" = { fg = "iris", modifiers = ["bold"] }
+
+"ui.window" = { fg = "overlay", bg = "base" }
+"ui.help" = { fg = "subtle", bg = "overlay" }
+
+"ui.menu" = { fg = "rose" }
+"ui.menu.selected" = { fg = "text" }
+"ui.menu.scroll" = { fg = "muted" }
+
+"ui.text" = { fg = "text" }
+"ui.text.focus" = { bg = "overlay" }
+"ui.text.info" = { fg = "subtle" }
+
+"ui.virtual.jump-label" = { fg = "love", modifiers = ["bold"] }
+"ui.virtual.ruler" = { bg = "overlay" }
+"ui.virtual.whitespace" = { fg = "highlight_high" }
+"ui.virtual.indent-guide" = { fg = "muted" }
+"ui.virtual.inlay-hint" = { fg = "subtle" }
+
+
+
+"ui.selection" = { bg = "overlay" }
+"ui.selection.primary" = { bg = "highlight_med" }
+
+"ui.cursorline.primary" = { bg = "highlight_low" }
+"ui.cursorline.secondary" = { bg = "surface" }
+
+"warning" = "gold"
+"error" = "love"
+"info" = "foam"
+"hint" = "iris"
+"debug" = "rose"
+
+"diagnostic" = { underline = { color = "subtle", style = "curl" } }
+"diagnostic.hint" = { underline = { color = "iris", style = "curl" } }
+"diagnostic.info" = { underline = { color = "foam", style = "curl" } }
+"diagnostic.warning" = { underline = { color = "gold", style = "curl" } }
+"diagnostic.error" = { underline = { color = "love", style = "curl" } }
+"special" = "rose"
+
+"attribute" = "iris"
+
+"type" = "foam"
+# "type.builtin" = ""
+
+"constructor" = "foam"
+
+"constant" = "foam"
+"constant.builtin" = "love"
+"constant.builtin.boolean" = "rose"
+"constant.character" = "gold"
+"constant.character.escape" = "pine"
+"constant.numeric" = "gold"
+# "constant.numeric.integer" = ""
+# "constant.numeric.float" = ""
+
+"string" = "gold"
+# "string.regexp" = ""
+# "string.special" = ""
+# "string.special.path" = ""
+# "string.special.url" = ""
+"string.special.symbol" = "iris"
+
+"comment" = { fg = "muted", modifiers = ["italic"] }
+# "comment.line" = ""
+# "comment.block" = ""
+# "comment.block.documentation" = ""
+
+"variable" = "text"
+"variable.builtin" = "love"
+"variable.parameter" = "iris"
+# "variable.other" = ""
+"variable.other.member" = "foam"
+
+"label" = "foam"
+
+"punctuation" = "subtle"
+# "punctuation.delimiter" = ""
+# "punctuation.bracket" = ""
+# "punctuation.special" = ""
+
+"keyword" = "pine"
+# "keyword.control" = ""
+# "keyword.control.conditional" = ""
+# "keyword.control.repeat" = ""
+# "keyword.control.import" = ""
+# "keyword.control.return" = ""
+# "keyword.control.exception" = ""
+"keyword.operator" = "subtle"
+# "keyword.directive" = ""
+# "keyword.function" = ""
+# "keyword.storage" = ""
+# "keyword.storage.type" = ""
+# "keyword.storage.modifier" = ""
+
+"operator" = "subtle"
+
+"function" = "rose"         # maybe pine
+"function.builtin" = "love"
+# "function.method" = ""
+# "function.macro" = ""
+# "function.special" = ""
+
+"tag" = "foam"
+
+"namespace" = "text"
+
+"markup.heading.marker" = "muted"
+"markup.heading" = { fg = "iris", modifiers = ["bold"] }
+"markup.heading.1" = { fg = "iris", modifiers = ["bold"] }
+"markup.heading.2" = { fg = "foam", modifiers = ["bold"] }
+"markup.heading.3" = { fg = "rose", modifiers = ["bold"] }
+"markup.heading.4" = { fg = "gold", modifiers = ["bold"] }
+"markup.heading.5" = { fg = "pine", modifiers = ["bold"] }
+"markup.heading.6" = { fg = "foam", modifiers = ["bold"] }
+# "markup.heading.completion" = ""
+# "markup.heading.hover" = ""
+"markup.list" = "muted"
+# "markup.list.unnumbered" = ""
+# "markup.list.numbered" = ""
+"markup.bold" = { modifiers = ["bold"] }
+"markup.italic" = { modifiers = ["italic"] }
+"markup.strikethrough" = { modifiers = ["crossed_out"] }
+"markup.link" = "iris"
+"markup.link.url" = { fg = "iris", underline = { color = "iris", style = "line" } }
+"markup.link.label" = "subtle"
+"markup.link.text" = "foam"
+"markup.quote" = "subtle"
+"markup.raw" = "subtle"
+"markup.raw.inline" = "gold"
+# "markup.raw.inline.completion" = {}
+# "markup.raw.inline.hover" = {}
+"markup.raw.block" = "gold"
+# "markup.normal" = ""
+# "markup.normal.completion" = ""
+# "markup.normal.hover" = ""
+
+"diff" = "overlay"
+"diff.plus" = "foam"
+"diff.minus" = "love"
+"diff.delta" = "highlight_high"
+# "diff.delta.moved" = ""
+
+[palette]
+base = "#191724"
+surface = "#1f1d2e"
+overlay = "#26233a"
+muted = "#6e6a86"
+subtle = "#908caa"
+text = "#e0def4"
+love = "#eb6f92"
+love_10 = "#311f30"
+gold = "#f6c177"
+gold_10 = "#30282c"
+rose = "#ebbcba"
+rose_10 = "#2f2834"
+pine = "#31748f"
+pine_10 = "#1a2030"
+foam = "#9ccfd8"
+foam_10 = "#252937"
+iris = "#c4a7e7"
+iris_10 = "#2b2539"
+highlight_low = "#21202e"
+highlight_med = "#403d52"
+highlight_high = "#524f67"

--- a/installation/roles/acikgozb.shell/templates/.bashrc.j2
+++ b/installation/roles/acikgozb.shell/templates/.bashrc.j2
@@ -46,7 +46,7 @@ export ANSIBLE_HOME="${XDG_CONFIG_HOME}/ansible"
 export ANSIBLE_CONFIG="${XDG_CONFIG_HOME}/ansible/ansible.cfg"
 export ANSIBLE_GALAXY_CACHE_DIR="${XDG_CACHE_HOME}/ansible/galaxy_cache"
 
-export EDITOR="nvim"
+export EDITOR="{{ editor }}"
 
 # Starship.
 eval "$(starship init bash)"

--- a/installation/vars/user_vars.sample.yml
+++ b/installation/vars/user_vars.sample.yml
@@ -8,6 +8,9 @@ xdg_data_home: "/home/{{ lookup('env', 'USER') }}/.local/share"
 xdg_bin_home: "/home/{{ lookup('env', 'USER') }}/.local/bin"
 xdg_cache_home: "/home/{{ lookup('env', 'USER') }}/.cache"
 
+# The $EDITOR to install. Available values are 'helix' and 'nvim'.
+editor: "helix"
+
 # Path to store downloaded source files.
 lib_path: "/home/{{ lookup('env', 'USER' ) }}/.local/lib"
 


### PR DESCRIPTION
With this commit, `dotfiles` now supports installing "Helix" as an alternative editor to Neovim.

Along with this change, several other improvements are made for `acikgozb.editor`:

- Necessary LSP's are installed on to the host. This wasn't necessary before due to the fact that the LSP's and other tools were installed with Mason plugin in Neovim. Helix, on the other hand, requires the LSP's to exist on the host under $PATH.

- A new field `version` is added to packages that are installed via `npm install` to install a specific version if needed.

- Zip archive support is added to prebuilt binary installations.