### PR TITLE
Add AURORA_LIB_PATH to shell environment

### DIFF
--- a/.config/bash/.bashrc
+++ b/.config/bash/.bashrc
@@ -14,6 +14,9 @@ export XDG_CACHE_HOME="/home/acikgozb/.cache"
 # .bash_history loc.
 export HISTFILE="$XDG_STATE_HOME/bash/history"
 
+# Aurora lib path (AUR).
+export AURORA_LIB_PATH="/home/acikgozb/.local/lib"
+
 # $PATH.
 if ! grep -q "$XDG_BIN_HOME:" <<< "$PATH"; then
     export PATH="$XDG_BIN_HOME:$PATH"

--- a/installation/roles/acikgozb.shell/templates/.bashrc.j2
+++ b/installation/roles/acikgozb.shell/templates/.bashrc.j2
@@ -14,6 +14,9 @@ export XDG_CACHE_HOME="{{ xdg_cache_home }}"
 # .bash_history loc.
 export HISTFILE="$XDG_STATE_HOME/bash/history"
 
+# Aurora lib path (AUR).
+export AURORA_LIB_PATH="{{ lib_path }}"
+
 # $PATH.
 if ! grep -q "$XDG_BIN_HOME:" <<< "$PATH"; then
     export PATH="$XDG_BIN_HOME:$PATH"


### PR DESCRIPTION
This variable is used by `aurora` to clone the packages under the specified directory.

In order to be in sync with the rest of the installation, the path is set to `{{ lib_path }}`.