### PR TITLE
Disable text wrapping at text width in Helix

### DIFF
--- a/.config/helix/config.toml
+++ b/.config/helix/config.toml
@@ -29,7 +29,7 @@ right = ["version-control", "diagnostics", "file-type"]
 
 [editor.soft-wrap]
 enable = true
-wrap-at-text-width = true
+wrap-at-text-width = false
 
 [editor.inline-diagnostics]
 cursor-line = "disable"

--- a/installation/roles/acikgozb.editor/templates/helix.config.toml.j2
+++ b/installation/roles/acikgozb.editor/templates/helix.config.toml.j2
@@ -29,7 +29,7 @@ right = ["version-control", "diagnostics", "file-type"]
 
 [editor.soft-wrap]
 enable = true
-wrap-at-text-width = true
+wrap-at-text-width = false
 
 [editor.inline-diagnostics]
 cursor-line = "disable"


### PR DESCRIPTION
The wrapped lines disrupt relative line jumping.

For example, if the target line is 5 lines above, but the current line is wrapped as 3 lines, then `5k` acts like `2k`.

As a temporary solution, the text wrapping is disabled for text width. If the text is too long to fit the screen, the line is still wrapped.