### PR TITLE
Change hyprland active border color

### DIFF
--- a/.config/hypr/hyprland.conf
+++ b/.config/hypr/hyprland.conf
@@ -75,7 +75,7 @@ general {
     border_size = 2
 
     # https://wiki.hyprland.org/Configuring/Variables/#variable-types for info about colors
-    col.active_border = rgba(333333ee)
+    col.active_border = rgba(f6c177ee) # rose-pine theme, color gold.
     col.inactive_border = rgba(00000000)
 
     # Set to true enable resizing windows by clicking and dragging on borders and gaps


### PR DESCRIPTION
The color is changed to rose-pine gold to:

- Allow the active window to be more visible to the user,
- Be in sync with the overall theming with the other tools.