### PR TITLE
Add a Git alias to show Git aliases

### DIFF
--- a/.config/git/config
+++ b/.config/git/config
@@ -21,3 +21,4 @@
     s = status
     l = log --graph
     co = checkout
+    alias = config get --all --show-names --regexp "^alias"

--- a/installation/roles/acikgozb.git/templates/config.j2
+++ b/installation/roles/acikgozb.git/templates/config.j2
@@ -21,3 +21,4 @@
     s = status
     l = log --graph
     co = checkout
+    alias = config get --all --show-names --regexp "^alias"


### PR DESCRIPTION
The alias can be called as `git alias`.