### PR TITLE
Update Helix configuration

### DIFF
--- a/.config/helix/config.toml
+++ b/.config/helix/config.toml
@@ -43,5 +43,7 @@ ret = "goto_word"
 [keys.normal.g]
 e = ["goto_last_line", "align_view_center"]
 
+[keys.select]
+ret = "goto_word"
 # Hard wrap the selection based on text width, e.g Git commit messages
 C-r = ":reflow"

--- a/.config/helix/config.toml
+++ b/.config/helix/config.toml
@@ -40,10 +40,8 @@ a = ["append_mode", "collapse_selection"]
 i = ["insert_mode", "collapse_selection"]
 ret = "goto_word"
 
-# NOTE: Experimental, I might stop using jumplist later on.
-C-h = "jump_backward"
-C-l = "jump_forward"
-[keys.normal.space]
-a = "save_selection"
-# Hard wrap the selection based on text width, e.g Git commit messages.
+[keys.normal.g]
+e = ["goto_last_line", "align_view_center"]
+
+# Hard wrap the selection based on text width, e.g Git commit messages
 C-r = ":reflow"

--- a/.config/helix/config.toml
+++ b/.config/helix/config.toml
@@ -29,7 +29,7 @@ right = ["diagnostics", "file-type", "version-control"]
 
 [editor.soft-wrap]
 enable = true
-wrap-at-text-width = false
+wrap-at-text-width = true
 
 [editor.inline-diagnostics]
 cursor-line = "disable"
@@ -45,3 +45,5 @@ C-h = "jump_backward"
 C-l = "jump_forward"
 [keys.normal.space]
 a = "save_selection"
+# Hard wrap the selection based on text width, e.g Git commit messages.
+C-r = ":reflow"

--- a/.config/helix/config.toml
+++ b/.config/helix/config.toml
@@ -25,7 +25,7 @@ follow-symlinks = true
 mode.normal = "NORMAL"
 mode.insert = "INSERT"
 mode.select = "SELECT"
-right = ["version-control", "diagnostics", "file-type"]
+right = ["diagnostics", "file-type", "version-control"]
 
 [editor.soft-wrap]
 enable = true


### PR DESCRIPTION
This PR contains changes that were thought necessary:

**Hard Wrap**

Previously, there were only soft wrapping enabled at the end of the line.
Hard wrapping weren't there and this caused issues with Git commit messages, since soft-wrap isn't suffice for commits. The previous solution was to manually format the lines, which wasn't ideal.

With this PR, a keymap is added for a command called `:reflow`, which hard-wraps the lines in a selection, potentially solving the formatting for Git commit messages. 

**Going the last line of a buffer and centering it**

There are two keymaps: `ge` for going the last line of a buffer and `zz` to center it.
Since these commands are frequently used together, the `ge` keymap is updated to center the text as well.

The other changes (statusline, goto_word) are experimental changes that are subject to change.
