### PR TITLE
feat: installation: Add `fcb` to the installation

### DIFF
--- a/installation/README.md
+++ b/installation/README.md
@@ -182,6 +182,7 @@ Packages:
 - `eslint_d`
 - `typescript`
 - `jq`
+- `fcb`
 - `shellcheck`
 - `golangci-lint`
 - `fzf`

--- a/installation/roles/acikgozb.editor/README.md
+++ b/installation/roles/acikgozb.editor/README.md
@@ -39,6 +39,7 @@ Here is a list of the programs that are installed (the numbers indicate the inst
 - `eslint_d` (2)
 - `typescript` (2)
 - `jq` (3)
+- `fcb` (3)
 - `shellcheck` (3)
 - `golangci-lint` (3)
 - `fzf` (3)

--- a/installation/roles/acikgozb.editor/defaults/main.yml
+++ b/installation/roles/acikgozb.editor/defaults/main.yml
@@ -60,6 +60,10 @@ programs:
         amd64: 'https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-amd64'
       extract: "false"
 
+    - name: fcb
+      url:
+        amd64: 'https://github.com/acikgozb/fcb/releases/download/v0.1.0/fcb-x86_64-unknown-linux-gnu.tar.gz'
+
     - name: shellcheck
       url:
         amd64: 'https://github.com/koalaman/shellcheck/releases/download/stable/shellcheck-stable.linux.x86_64.tar.xz'


### PR DESCRIPTION
[fcb](https://github.com/acikgozb/fcb) is added to the main installation, under `acikgozb.editor` as a prebuilt binary.