### PR TITLE
feat(hyprpaper): Disable hyprpaper

### DIFF
--- a/.config/alacritty/alacritty.toml
+++ b/.config/alacritty/alacritty.toml
@@ -4,7 +4,7 @@ import = ["/home/acikgozb/.config/alacritty/themes/rose-pine.toml"]
 [window]
 padding = {x = 10, y = 10}
 decorations = "None"
-opacity = 0.7
+opacity = 0.8
 
 [font]
 normal = { family = "UbuntuMono Nerd Font Mono", style = "Regular" }

--- a/.config/hypr/hyprland.conf
+++ b/.config/hypr/hyprland.conf
@@ -38,7 +38,6 @@ $fileExplorer = nautilus
 ### AUTOSTART ###
 #################
 
-exec-once = hyprpaper
 # Allow GUI apps to request elevated privileges if needed.
 exec-once = systemctl --user start hyprpolkitagent
 # Configure xdg-desktop-portal-hyprland to enable screensharing.
@@ -70,12 +69,12 @@ env = HYPRCURSOR_SIZE,24
 # https://wiki.hyprland.org/Configuring/Variables/#general
 general {
     gaps_in = 5
-    gaps_out = 15
+    gaps_out = 0
 
     border_size = 2
 
     # https://wiki.hyprland.org/Configuring/Variables/#variable-types for info about colors
-    col.active_border = rgba(f6c177ee) # rose-pine theme, color gold.
+    col.active_border = rgba(eb6f92ee) # rose-pine theme, color red.
     col.inactive_border = rgba(00000000)
 
     # Set to true enable resizing windows by clicking and dragging on borders and gaps
@@ -85,7 +84,6 @@ general {
     allow_tearing = false
 
     layout = dwindle
-
 }
 
 # https://wiki.hyprland.org/Configuring/Variables/#decoration


### PR DESCRIPTION
I've given up trying to find suitable wallpapers to use as my terminal background. Therefore, `hyprpaper` is disabled for now.

I'm intentionally keeping the template files the same, just in case.