### PR TITLE
feat(hyprland): Remove PoC desktop environment mods

### DIFF
--- a/.config/hypr/hyprland.conf
+++ b/.config/hypr/hyprland.conf
@@ -28,8 +28,6 @@ monitor=eDP-1,preferred,auto,1
 $terminal = /home/acikgozb/.local/bin/custom/alacritty
 $browser = librewolf
 $menu = rofi -show drun
-$power = /home/acikgozb/.local/bin/custom/devx-power
-$wifi = /home/acikgozb/.local/bin/custom/devx-wifi
 $bluetooth = /home/acikgozb/.local/bin/custom/devx-bluetooth
 $fileExplorer = nautilus
 
@@ -169,8 +167,6 @@ gestures {
 # See https://wiki.hyprland.org/Configuring/Keywords/
 $mainMod = ALT_L # Sets "Alt" key as the main modifier.
 
-bind = $mainMod, Q, exec, $power
-bind = $mainMod, W, exec, $wifi
 bind = $mainMod, R, exec, $bluetooth
 bind = $mainMod, T, exec, $terminal
 bind = $mainMod, B, exec, $browser


### PR DESCRIPTION
The robust versions of `power` and `wifi` are implemented as `hpm` and `wl` respectively.

Therefore, the PoC scripts are removed from `hyprland`.

I'll be using the tools to see how the experience is. Therefore, the template files are kept unchanged for now.