### PR TITLE
feat(git-alias): Add alias for branch cleanup

### DIFF
--- a/.config/git/config
+++ b/.config/git/config
@@ -24,4 +24,7 @@
     co = checkout
     d = diff
     b = branch
+    bcr = "!bcr() { git remote prune origin; branches=$(git b -r | rg -v -e "main" -e "master" | cut -d'/' -f2-); if [[ -n "$branches" ]]; then git push origin --delete $branches; fi; }; bcr"
+    bcl = "!bcl() { branches=$(git b -l | rg -v -e "main" -e "master"); if [[ -n "$branches" ]]; then git b -d $branches; fi; }; bcl"
+    bca = "!bca() { git bcr && git bcl; }; bca"
     alias = config get --all --show-names --regexp "^alias"


### PR DESCRIPTION
Three aliases are added to remove every single local/remote-tracking/remote branch that is not `main` or `master`.

For me, any branch other than `main` or `master` falls under one of the categories below:

- Branches that were already merged to the main trunk, (1)
- Branches that track non-existing remote branches, (2)
- Local branches that were created and eventually abandoned. (3)

Here are the target categories for each alias:

`git bcr` is added for (1) and (2).
`git bcl` is added for (3).
`git bca` is added to do (1), (2) and (3) all at once.

Resolves #47.