### PR TITLE
feat(zellij): Disable session resurrection

### DIFF
--- a/.config/zellij/config.kdl
+++ b/.config/zellij/config.kdl
@@ -400,7 +400,7 @@ attach_to_session true
 // Options:
 //   - true (default)
 //   - false
-session_serialization true
+session_serialization false
  
 // Whether pane viewports are serialized along with the session, default is false
 // Options:

--- a/installation/roles/acikgozb.multiplexer/templates/zellij.config.kdl.j2
+++ b/installation/roles/acikgozb.multiplexer/templates/zellij.config.kdl.j2
@@ -400,7 +400,7 @@ attach_to_session true
 // Options:
 //   - true (default)
 //   - false
-session_serialization true
+session_serialization false
  
 // Whether pane viewports are serialized along with the session, default is false
 // Options:


### PR DESCRIPTION
1 - Some processes (like `helix`) does not behave well after the session is resurrected by `zellij`.

2 - I find myself constantly starting from scratch by removing the previous session upon a boot, like `tmux`.

Therefore, the session resurrection is disabled for now.