### PR TITLE
feat(lang): Update C and Rust LSP configuration

### DIFF
--- a/.config/helix/languages.toml
+++ b/.config/helix/languages.toml
@@ -4,6 +4,9 @@ name = "c"
 auto-format = true
 formatter = { command = "clang-format" }
 
+[language-server.clangd.config]
+fallbackFlags = ["-std=c99"]
+
 # Rust.
 [language-server.rust-analyzer.config.check]
 command = "clippy"

--- a/.config/helix/languages.toml
+++ b/.config/helix/languages.toml
@@ -14,6 +14,9 @@ command = "clippy"
 [language-server.rust-analyzer.config.cargo]
 features = "all"
 
+[language-server.rust-analyzer.config.cfg]
+setTest = false
+
 # YAML.
 [language-server.yaml-language-server.config.yaml]
 completion = true


### PR DESCRIPTION
This PR introduces a small update to `clangd` and `rust-analzyer`:

- `-std=c99` is used as a fallback std for `clangd`.
- `cfg.setTest` is set to false for `rust-analyzer`. For more information, please see https://github.com/acikgozb/dotfiles/commit/ffa62eebec68c6de4331fc82db4587476ce80535.