### PR TITLE
feat(hyprland): Add binds to resize the active win

### DIFF
--- a/.config/hypr/hyprland.conf
+++ b/.config/hypr/hyprland.conf
@@ -195,6 +195,12 @@ bind = $mainMod, L, movewindow, r
 bind = $mainMod, J, movewindow, d
 bind = $mainMod, K, movewindow, u
 
+# Resize the focused window.
+bind = $mainMod&Control_L, H, resizeactive, -20 0
+bind = $mainMod&Control_L, L, resizeactive, 20 0
+bind = $mainMod&Control_L, J, resizeactive, 0 20
+bind = $mainMod&Control_L, K, resizeactive, 0 -20
+
 # Switch workspaces.
 bind = $mainMod, 1, workspace, 1
 bind = $mainMod, 2, workspace, 2


### PR DESCRIPTION
The changes are not added to `hyprland`'s template file just yet. 
I need time to experiment with this a bit, but the template file will be updated accordingly before the next release.