### PR TITLE
feat(fonts): Simplify font configuration

### DIFF
--- a/.config/alacritty/alacritty.toml
+++ b/.config/alacritty/alacritty.toml
@@ -7,7 +7,7 @@ decorations = "None"
 opacity = 0.8
 
 [font]
-normal = { family = "UbuntuMono Nerd Font Mono", style = "Regular" }
+normal = { family = "IosevkaSS14", style = "Regular" }
 size = 16.0
 offset = { x = 0, y = 1 }
 

--- a/installation/roles/acikgozb.system/README.md
+++ b/installation/roles/acikgozb.system/README.md
@@ -192,11 +192,14 @@ The provided path should contain the whole path of the repository (e.g. `/path/t
 `rofi_font_family`
 
 This variable defines the font that will be used in `rofi-wayland`.
+By default, it is set to user provided UI font family + style  `ui_font_family ui_font_style`.
 By default, it is aimed to be in sync with the `main_font_family` provided by the user and the `Propo` variant is used.
 
-Example: By default, `UbuntuMono Nerd Font` is used as `main_font_family`, and `rofi_font_family` is set to `UbuntuMono Nerd Font Propo`.
+Example:
 
-If a provided `main_font_family` does not contain a `Propo` variant, then users' need to specify a value for `rofi_font_family` as well.
+- `ui_font_family`: `UbuntuMono Nerd Font`
+- `ui_font_style`: `Propo`
+- `rofi_font_family`: `UbuntuMono Nerd Font Propo`
 
 `rofi_font_size`
 

--- a/installation/roles/acikgozb.system/defaults/main.yml
+++ b/installation/roles/acikgozb.system/defaults/main.yml
@@ -29,7 +29,7 @@ screen_utilities:
 
 devx_clone_path: "{{ git_projects_path }}/devx-scripts"
 
-rofi_font_family: "{{ main_font_family }} Propo"
+rofi_font_family: "{{ ui_font_family }} {{ ui_font_style }}"
 rofi_font_size: "16"
 rofi_prompt_placeholder: "Search..."
 

--- a/installation/roles/acikgozb.term/defaults/main.yml
+++ b/installation/roles/acikgozb.term/defaults/main.yml
@@ -11,4 +11,5 @@ alacritty_deps:
     - libxkbcommon
     - python
 
-terminal_font: "{{ main_font_family }} Mono"
+terminal_font_family: "{{ terminal_font_family }}"
+terminal_font_style: "{{ terminal_font_style }}"

--- a/installation/roles/acikgozb.term/templates/alacritty.toml.j2
+++ b/installation/roles/acikgozb.term/templates/alacritty.toml.j2
@@ -7,7 +7,7 @@ decorations = "None"
 opacity = 0.7
 
 [font]
-normal = { family = "{{ terminal_font }}", style = "Regular" }
+normal = { family = "{{ terminal_font_family }}", style = "{{ terminal_font_style }}" }
 size = 16.0
 offset = { x = 0, y = 1 }
 

--- a/installation/vars/user_vars.sample.yml
+++ b/installation/vars/user_vars.sample.yml
@@ -45,7 +45,12 @@ wm_browser_args: "--new-tab https://site1.com --new-tab https://site2.com"
 # The path that holds users Git projects.
 git_projects_path: "/home/{{ lookup('env', 'USER') }}/personal"
 
-# An existing user font.
-# For the terminal, "Mono" is appended to the specified font: e.g. UbuntuMono Nerd Font Mono
-# For UI programs such as rofi, "Propo" is appended to the specified font: e.g. UbuntuMono Nerd Font Propo
-main_font_family: "UbuntuMono Nerd Font"
+# Fonts.
+# The fonts specified below must exist on the host.
+# If they do not exist, users need to install them after the
+# dotfiles installation.
+terminal_font_family: "IosevkaSS14"
+teminal_font_style: "Regular"
+
+ui_font_family: "UbuntuMono Nerd Font"
+ui_font_style: "Propo"


### PR DESCRIPTION
This commit simplifies the font configuration by adding four new variables to `user_vars.sample` that are expected to be provided by the user:

- `terminal_font_family`
- `terminal_font_style`
- `ui_font_family`
- `ui_font_style`

Right now, `terminal_*` variables are used by Alacritty, and `ui_*` variables are used by `rofi` only, since they are the only programs as of now that utilizes fonts.

With this change, this commit also changes the font that is used by Alacritty to `IosevkaSS14`.

Here is the font in action:
<img width="955" height="1200" alt="iosevka-ss14" src="https://github.com/user-attachments/assets/e96bd893-7969-44ca-b0c7-08972d8dc3fc" />
