### PR TITLE
fix(dns): Disable DNS over TLS for systemd-resolved

### DIFF
--- a/installation/roles/acikgozb.net/files/dns_servers.conf
+++ b/installation/roles/acikgozb.net/files/dns_servers.conf
@@ -1,4 +1,5 @@
 [Resolve]
-DNS= 1.1.1.1 2606:4700:4700::1111 # Cloudflare
+DNS=1.1.1.1#cloudflare-dns.com 1.0.0.1#cloudflare-dns.com
+DNSOverTLS=no
+DNSSec=no
 Cache=yes
-ReadEtcHosts=yes

--- a/installation/roles/acikgozb.net/templates/systemd-resolved.dns_servers.conf.j2
+++ b/installation/roles/acikgozb.net/templates/systemd-resolved.dns_servers.conf.j2
@@ -1,4 +1,5 @@
 [Resolve]
-DNS= 1.1.1.1 2606:4700:4700::1111 # Cloudflare
+DNS=1.1.1.1#cloudflare-dns.com 1.0.0.1#cloudflare-dns.com
+DNSOverTLS=no
+DNSSec=no
 Cache=yes
-ReadEtcHosts=yes


### PR DESCRIPTION
Enabling `DNSOverTLS` for `systemd-resolved` causes a non-deterministic behavior when resolving hostnames, resulting in up to n second(s) latency from time to time.

In order to speed up the name resolution, this option is disabled.